### PR TITLE
Data loaders and Optimizations

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,6 +28,15 @@
       }
     },
     {
+      "identity" : "dataloader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/GraphQLSwift/DataLoader",
+      "state" : {
+        "revision" : "5c27005aed25bc1dda9c5ad30289f96913500f83",
+        "version" : "2.2.0"
+      }
+    },
+    {
       "identity" : "fluent",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent.git",

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/multipart-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/leaf.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/GraphQLSwift/DataLoader", .upToNextMajor(from: "2.2.0")),
     ],
     targets: [
         .executableTarget(
@@ -36,6 +37,7 @@ let package = Package(
                 .product(name: "MultipartKit", package: "multipart-kit"),
                 .product(name: "Leaf", package: "leaf"),
                 .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "DataLoader", package: "DataLoader"),
             ]
         ),
         .testTarget(name: "AppTests", dependencies: [

--- a/Sources/App/Controllers/Auth/ResetController.swift
+++ b/Sources/App/Controllers/Auth/ResetController.swift
@@ -23,7 +23,7 @@ struct ResetController: RouteCollection {
     }
 
     func changePassword(req: Request) async throws -> ChangePasswordResponse {
-        let token = try await getAndVerifyAccessToken(req: req)
+        let token = try await getAccessToken(req: req)
         guard let auth = try await UserPassword.query(on: req.db)
                 .filter(\.$id == token.id)
                 .first() else {

--- a/Sources/App/Controllers/Auth/VerifyController.swift
+++ b/Sources/App/Controllers/Auth/VerifyController.swift
@@ -11,7 +11,7 @@ import Fluent
 struct VerifyController: RouteCollection {
     func boot(routes: RoutesBuilder) throws {
         routes.grouped("v0").grouped("auth").get("verify") { req in
-            try await verifyAccessToken(req: req)
+            _ = try await getAccessToken(req: req)
             return HTTPStatus.ok
         }
     }

--- a/Sources/App/Controllers/Blob/AvatarController.swift
+++ b/Sources/App/Controllers/Blob/AvatarController.swift
@@ -18,7 +18,7 @@ struct AvatarController: RouteCollection {
     }
 
     func deleteAvatar(req: Request) async throws -> HTTPResponseStatus {
-        let token = try await getAndVerifyAccessToken(req: req)
+        let token = try await getAccessToken(req: req)
         let user = try await RegisteredUser.find(token.id, on: req.db)
         user?.avatarHash = nil
         do {
@@ -32,7 +32,7 @@ struct AvatarController: RouteCollection {
     func uploadAvatar(req: Request) async throws -> AvatarHashResponse {
         print("uploading avatar")
         
-        let token = try await getAndVerifyAccessToken(req: req)
+        let token = try await getAccessToken(req: req)
         let user = try await RegisteredUser.find(token.id, on: req.db)
         
         guard let user = user else {

--- a/Sources/App/Ext/DataLoaderMiddleware.swift
+++ b/Sources/App/Ext/DataLoaderMiddleware.swift
@@ -11,7 +11,7 @@ import Vapor
 struct DataLoaderMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
         if (request.method == .POST) {
-            request.loaders = DataLoaders()
+            request.loaders = DataLoaders(on: request)
         }
         return try await next.respond(to: request)
     }

--- a/Sources/App/Ext/DataLoaderMiddleware.swift
+++ b/Sources/App/Ext/DataLoaderMiddleware.swift
@@ -1,0 +1,16 @@
+
+//
+//  DataLoaderMiddleware.swift
+//
+//
+//  Created by Shrish Deshpande on 03/07/24.
+//
+
+import Vapor
+
+struct DataLoaderMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        request.loaders = DataLoaders()
+        return try await next.respond(to: request)
+    }
+}

--- a/Sources/App/Ext/DataLoaderMiddleware.swift
+++ b/Sources/App/Ext/DataLoaderMiddleware.swift
@@ -10,7 +10,9 @@ import Vapor
 
 struct DataLoaderMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-        request.loaders = DataLoaders()
+        if (request.method == .POST) {
+            request.loaders = DataLoaders()
+        }
         return try await next.respond(to: request)
     }
 }

--- a/Sources/App/Ext/DataLoaders.swift
+++ b/Sources/App/Ext/DataLoaders.swift
@@ -6,9 +6,70 @@
 //
 
 import Vapor
+import Fluent
+import DataLoader
 
 class DataLoaders {
-    
+    public let request: Request
+
+    public lazy var users: DataLoader<Int, RegisteredUser> = DataLoader<Int, RegisteredUser>() { keys in
+        return RegisteredUser.query(on: self.request.db)
+          .filter(\.$id ~~ keys)
+          .all()
+          .map { users in
+              keys.map { key in
+                  DataLoaderFutureValue.success(users.first { $0.id! == key }!)
+              }
+          }
+    }
+
+    public lazy var followers: DataLoader<Int, Int> = DataLoader<Int, Int>() { keys in
+        return Follower.query(on: self.request.db)
+          .filter(\.$followed.$id ~~ keys)
+          .all()
+          .map { followers in
+              keys.map { key in
+                  DataLoaderFutureValue.success(followers.filter { $0.followed.id! == key }.count)
+              }
+          }
+    }
+
+    public lazy var following: DataLoader<Int, Int> = DataLoader<Int, Int>() { keys in
+        return Follower.query(on: self.request.db)
+          .filter(\.$follower.$id ~~ keys)
+          .all()
+          .map { following in
+              keys.map { key in
+                  DataLoaderFutureValue.success(following.filter { $0.follower.id! == key }.count)
+              }
+          }
+    }
+
+    public lazy var postLikes: DataLoader<String, Int> = DataLoader<String, Int>() { keys in
+        return LikedPost.query(on: self.request.db)
+          .filter(\.$post.$id ~~ keys)
+          .all()
+          .map { likes in
+              keys.map { key in
+                  DataLoaderFutureValue.success(likes.filter { $0.post.id! == key }.count)
+              }
+          }
+    }
+
+    public lazy var badges: DataLoader<Int, [Badge]> = DataLoader<Int, [Badge]>() { keys in
+        return Badge.query(on: self.request.db)
+          .filter(\.$user.$id ~~ keys)
+          .all()
+          .map { badges in
+              keys.map { key in
+                  DataLoaderFutureValue.success(badges.filter { $0.user.id! == key })
+              }
+          }
+    }
+
+    public init(on request: Request) {
+        self.request = request
+    }
 }
 
 struct DataLoadersStorageKey: StorageKey {

--- a/Sources/App/Ext/DataLoaders.swift
+++ b/Sources/App/Ext/DataLoaders.swift
@@ -12,6 +12,8 @@ import DataLoader
 class DataLoaders {
     public let request: Request
 
+    // MARK: - User
+    
     public lazy var users: DataLoader<Int, RegisteredUser> = DataLoader<Int, RegisteredUser>() { keys in
         return RegisteredUser.query(on: self.request.db)
           .filter(\.$id ~~ keys)
@@ -29,7 +31,7 @@ class DataLoaders {
           .all()
           .map { followers in
               keys.map { key in
-                  DataLoaderFutureValue.success(followers.filter { $0.followed.id! == key }.count)
+                  DataLoaderFutureValue.success(followers.filter { $0.$followed.id == key }.count)
               }
           }
     }
@@ -40,18 +42,7 @@ class DataLoaders {
           .all()
           .map { following in
               keys.map { key in
-                  DataLoaderFutureValue.success(following.filter { $0.follower.id! == key }.count)
-              }
-          }
-    }
-
-    public lazy var postLikes: DataLoader<String, Int> = DataLoader<String, Int>() { keys in
-        return LikedPost.query(on: self.request.db)
-          .filter(\.$post.$id ~~ keys)
-          .all()
-          .map { likes in
-              keys.map { key in
-                  DataLoaderFutureValue.success(likes.filter { $0.post.id! == key }.count)
+                  DataLoaderFutureValue.success(following.filter { $0.$follower.id == key }.count)
               }
           }
     }
@@ -62,7 +53,32 @@ class DataLoaders {
           .all()
           .map { badges in
               keys.map { key in
-                  DataLoaderFutureValue.success(badges.filter { $0.user.id! == key })
+                  DataLoaderFutureValue.success(badges.filter { $0.$user.id == key })
+              }
+          }
+    }
+
+    // MARK: - Post
+    
+    // TODO: cache likes count?
+    public lazy var postLikes: DataLoader<String, Int> = DataLoader<String, Int>() { keys in
+        return LikedPost.query(on: self.request.db)
+          .filter(\.$post.$id ~~ keys)
+          .all()
+          .map { likes in
+              keys.map { key in
+                  DataLoaderFutureValue.success(likes.filter { $0.$post.id == key }.count)
+              }
+          }
+    }
+
+    public lazy var attachments: DataLoader<String, [Attachment]> = DataLoader<String, [Attachment]>() { keys in
+        return Attachment.query(on: self.request.db)
+          .filter(\.$parentId ~~ keys)
+          .all()
+          .map { attachments in
+              keys.map { key in
+                  DataLoaderFutureValue.success(attachments.filter { $0.parentId == key })
               }
           }
     }

--- a/Sources/App/Ext/DataLoaders.swift
+++ b/Sources/App/Ext/DataLoaders.swift
@@ -1,0 +1,16 @@
+//
+//  DataLoaders.swift
+//
+//
+//  Created by Shrish Deshpande on 03/07/24.
+//
+
+import Vapor
+
+class DataLoaders {
+    
+}
+
+struct DataLoadersStorageKey: StorageKey {
+    typealias Value = DataLoaders
+}

--- a/Sources/App/Ext/GraphQLMiddleware.swift
+++ b/Sources/App/Ext/GraphQLMiddleware.swift
@@ -1,6 +1,5 @@
-
 //
-//  DataLoaderMiddleware.swift
+//  GraphQLMiddleware.swift
 //
 //
 //  Created by Shrish Deshpande on 03/07/24.
@@ -8,10 +7,11 @@
 
 import Vapor
 
-struct DataLoaderMiddleware: AsyncMiddleware {
+struct GraphQLMiddleware: AsyncMiddleware {
     func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
-        if (request.method == .POST) {
+        if (request.method == .POST && request.route?.path[0] == "graphql") {
             request.loaders = DataLoaders(on: request)
+            request.token = try await getAccessToken(req: request)
         }
         return try await next.respond(to: request)
     }

--- a/Sources/App/Ext/Request+Loaders.swift
+++ b/Sources/App/Ext/Request+Loaders.swift
@@ -1,0 +1,21 @@
+//
+//  Request+Loaders.swift
+//
+//
+//  Created by Shrish Deshpande on 03/07/24.
+//
+
+import Vapor
+import Fluent
+import DataLoader
+
+extension Request {
+    var loaders: DataLoaders {
+        get {
+            self.storage[DataLoadersStorageKey.self]!
+        }
+        set {
+            self.storage[DataLoadersStorageKey.self] = newValue
+        }
+    }
+}

--- a/Sources/App/GraphQL/Mutation/Resolver+MutateConfessions.swift
+++ b/Sources/App/GraphQL/Mutation/Resolver+MutateConfessions.swift
@@ -11,7 +11,7 @@ import Fluent
 
 extension Resolver {
     func confess(request: Request, arguments: CreatePostArgs) async throws -> Confession {
-        let token = try await getAndVerifyAccessToken(req: request)
+        let token = request.token
         try await assertScope(request: request, .confessions)
         let confession: Confession = .init(creatorId: token.id, content: arguments.content)
         try await confession.create(on: request.db)

--- a/Sources/App/GraphQL/Mutation/Resolver+MutatePosts.swift
+++ b/Sources/App/GraphQL/Mutation/Resolver+MutatePosts.swift
@@ -43,34 +43,31 @@ extension Resolver {
     
     // MARK: Creating posts
     func createPost(request: Request, arguments: CreatePostArgs) async throws -> Post {
-        let token = try await getAndVerifyAccessToken(req: request)
         try await assertScope(request: request, .createPosts)
         if arguments.attachments != nil && arguments.attachments!.count > 8 {
             throw Abort(.badRequest, reason: "Too many attachments")
         }
-        let post = Post(userId: token.id, content: arguments.content)
+        let post = Post(userId: request.token.id, content: arguments.content)
         return try await newPost(post: post, attachments: arguments.attachments, on: request.db)
     }
 
     func replyToPost(request: Request, arguments: ReplyToPostArgs) async throws -> Post {
-        let token = try await getAndVerifyAccessToken(req: request)
         try await assertScope(request: request, .createPosts)
         let post = try await Post.query(on: request.db).filter(\.$id == arguments.to).first()
           .unwrap(orError: Abort(.notFound, reason: "Could not find post with given ID")).get()
-        let reply = Post(userId: token.id, content: arguments.content)
+        let reply = Post(userId: request.token.id, content: arguments.content)
         reply.$reply.id = post.id
         return try await newPost(post: reply, attachments: arguments.attachments, on: request.db)
     }
 
     // MARK: Deleting posts
     func archivePost(request: Request, arguments: StringIdArgs) async throws -> Post {
-        let token = try await getAndVerifyAccessToken(req: request)
         try await assertScope(request: request, .deletePosts)
         let post = try await Post.query(on: request.db).filter(\.$id == arguments.id).first()
           .unwrap(orError: Abort(.notFound, reason: "Could not find post with given ID")).get()
         
-        if token.id != post.$creator.id {
-            request.logger.error("User \(token.id) tried to archive a post by \(post.$creator.id)")
+        if request.token.id != post.$creator.id {
+            request.logger.error("User \(request.token.id) tried to archive a post by \(post.$creator.id)")
             throw Abort(.forbidden, reason: "Not post creator")
         }
 
@@ -79,13 +76,12 @@ extension Resolver {
     }
 
     func deletePost(request: Request, arguments: StringIdArgs) async throws -> Post {
-        let token = try await getAndVerifyAccessToken(req: request)
         try await assertScope(request: request, .deletePosts)
         let post = try await Post.query(on: request.db).filter(\.$id == arguments.id).first()
           .unwrap(orError: Abort(.notFound, reason: "Could not find post with given ID")).get()
         
-        if token.id != post.$creator.id {
-            request.logger.error("User \(token.id) tried to delete a post by \(post.$creator.id)")
+        if request.token.id != post.$creator.id {
+            request.logger.error("User \(request.token.id) tried to delete a post by \(post.$creator.id)")
             throw Abort(.forbidden, reason: "Not post creator")
         }
 
@@ -94,13 +90,12 @@ extension Resolver {
     }
     
     func restorePost(request: Request, arguments: StringIdArgs) async throws -> Post {
-        let token = try await getAndVerifyAccessToken(req: request)
         try await assertScope(request: request, .createPosts)
         let post = try await Post.query(on: request.db).withDeleted().filter(\.$id == arguments.id).first()
           .unwrap(orError: Abort(.notFound, reason: "Could not find post with given ID")).get()
         
-        if token.id != post.$creator.id {
-            request.logger.error("User \(token.id) tried to restore a post by \(post.$creator.id)")
+        if request.token.id != post.$creator.id {
+            request.logger.error("User \(request.token.id) tried to restore a post by \(post.$creator.id)")
             throw Abort(.forbidden, reason: "Not post creator")
         }
         
@@ -111,24 +106,22 @@ extension Resolver {
     // MARK: Liking posts
     func likePost(request: Request, arguments: StringIdArgs) async throws -> Int {
         try await assertScope(request: request, .createPosts)
-            let token = try await getAndVerifyAccessToken(req: request)
-            let lp: LikedPost = .init(postId: arguments.id, userId: token.id)
-            let post: Post? = try await Post.find(arguments.id, on: request.db)
-            guard let post = post else {
-                throw Abort(.notFound, reason: "Could not find post with given ID")
-            }            
-            try await lp.create(on: request.db)
-            let notif: Notification = .like(target: post.$creator.id, user: token.id, post: arguments.id)
-            try await notif.create(on: request.db)
-            return try await LikedPost.query(on: request.db).filter(\.$post.$id == arguments.id).count().get()
+        let lp: LikedPost = .init(postId: arguments.id, userId: request.token.id)
+        let post: Post? = try await Post.find(arguments.id, on: request.db)
+        guard let post = post else {
+            throw Abort(.notFound, reason: "Could not find post with given ID")
+        }            
+        try await lp.create(on: request.db)
+        let notif: Notification = .like(target: post.$creator.id, user: request.token.id, post: arguments.id)
+        try await notif.create(on: request.db)
+        return try await LikedPost.query(on: request.db).filter(\.$post.$id == arguments.id).count().get()
     }
     
     func unlikePost(request: Request, arguments: StringIdArgs) async throws -> Int {
         try await assertScope(request: request, .createPosts)
-        let token = try await getAndVerifyAccessToken(req: request)
         let lp = try await LikedPost.query(on: request.db)
           .filter(\.$post.$id == arguments.id)
-          .filter(\.$user.$id == token.id)
+          .filter(\.$user.$id == request.token.id)
           .first()
           .unwrap(orError: Abort(.notFound, reason: "Could not find post with given ID"))
           .get()

--- a/Sources/App/GraphQL/Query/Resolver+GetConfessions.swift
+++ b/Sources/App/GraphQL/Query/Resolver+GetConfessions.swift
@@ -11,14 +11,12 @@ import Vapor
 
 extension Resolver {
     func getConfessions(request: Request, arguments: PaginationArgs) async throws -> Page<Confession> {
-        try await verifyAccessToken(req: request)
         return try await Confession.query(on: request.db)
             .sort(\.$id, .descending)
             .paginate(.init(page: arguments.page, per: arguments.per))
     }
 
     func getConfessionById(request: Request, arguments: IntIdArgs) async throws -> Confession {
-        try await verifyAccessToken(req: request)
         guard let confession = try await Confession.find(arguments.id, on: request.db) else {
             throw Abort(.notFound, reason: "Confession not found")
         }
@@ -26,7 +24,6 @@ extension Resolver {
     }
 
     func getLatestConfession(request: Request, arguments: NoArguments) async throws -> Confession? {
-        try await verifyAccessToken(req: request)
         return try await Confession.query(on: request.db)
           .sort(\.$id, .descending)
           .first()

--- a/Sources/App/GraphQL/Query/Resolver+GetPosts.swift
+++ b/Sources/App/GraphQL/Query/Resolver+GetPosts.swift
@@ -29,7 +29,6 @@ struct PostsPaginationArgs: Codable {
 
 extension Resolver {
     func getPostsByUser(request: Request, arguments: PostsPaginationArgs) async throws -> Page<Post> {
-        try await verifyAccessToken(req: request)
         return try await Post.query(on: request.db)
             .filter(\.$creator.$id == arguments.creator)
             .sort(\.$createdAt, .descending)
@@ -37,7 +36,6 @@ extension Resolver {
     }
     
     func getPostById(request: Request, arguments: StringIdArgs) async throws -> Post {
-        try await verifyAccessToken(req: request)
         return try await Post.query(on: request.db)
             .filter(\.$id == arguments.id)
             .first()
@@ -46,7 +44,6 @@ extension Resolver {
     }
     
     func getRecentPosts(request: Request, arguments: RecentPostsArgs) async throws -> [Post] {
-        try await verifyAccessToken(req: request)
         let before = arguments.beforeDate ?? Date.now
 
         return try await Post.query(on: request.db)

--- a/Sources/App/GraphQL/Relation/Badge+Resolver.swift
+++ b/Sources/App/GraphQL/Relation/Badge+Resolver.swift
@@ -11,6 +11,6 @@ import Graphiti
 
 extension Badge {
     func getUser(request: Request, arguments: NoArguments) async throws -> RegisteredUser {
-        return try await self.$user.get(on: request.db)
+        return try await request.loaders.users.load(key: self.$user.id, on: request.eventLoop)
     }
 }

--- a/Sources/App/GraphQL/Relation/Notification+Resolver.swift
+++ b/Sources/App/GraphQL/Relation/Notification+Resolver.swift
@@ -13,9 +13,12 @@ extension Notification {
     func getTargetUser(request: Request, arguments: NoArguments) async throws -> RegisteredUser {
         return try await self.$targetUser.get(on: request.db)
     }
-
+    
     func getReferenceUser(request: Request, arguments: NoArguments) async throws -> RegisteredUser? {
-        return try await self.$referenceUser.get(on: request.db)
+        guard let refId = self.$referenceUser.id else {
+            return nil
+        }
+        return try await request.loaders.users.load(key: refId, on: request.eventLoop)
     }
 
     func getReferencePost(request: Request, arguments: NoArguments) async throws -> Post? {

--- a/Sources/App/GraphQL/Relation/Post+Resolver.swift
+++ b/Sources/App/GraphQL/Relation/Post+Resolver.swift
@@ -33,8 +33,7 @@ extension Post {
 
     // TODO: data loader for this
     func selfLiked(request: Request, arguments: NoArguments) async throws -> Bool {
-        let token = try await getAndVerifyAccessToken(req: request)
-        return try await self.$likes.isAttached(toID: token.id, on: request.db)
+        return try await self.$likes.isAttached(toID: request.token.id, on: request.db)
     }
 
     func getAttachments(request: Request, arguments: NoArguments) async throws -> [String] {

--- a/Sources/App/GraphQL/Relation/RegisteredUser+Resolver.swift
+++ b/Sources/App/GraphQL/Relation/RegisteredUser+Resolver.swift
@@ -59,6 +59,10 @@ extension RegisteredUser {
     }
 
     func getNotifications(request: Request, arguments: NoArguments) async throws -> [Notification] {
+        let token = try await getAndVerifyAccessToken(req: request)
+        if token.id != self.id {
+            throw Abort(.forbidden)
+        }
         return try await self.$notifications.query(on: request.db).all()
     }
 

--- a/Sources/App/GraphQL/Relation/RegisteredUser+Resolver.swift
+++ b/Sources/App/GraphQL/Relation/RegisteredUser+Resolver.swift
@@ -12,7 +12,7 @@ import Graphiti
 // TODO: use a data loader (these are N+1 queries)
 extension RegisteredUser {
     func isSelf(request: Request, arguments: NoArguments) async throws -> Bool {
-        return try await getAndVerifyAccessToken(req: request).id == self.id
+        return request.token.id == self.id
     }
     
     func getPosts(request: Request, arguments: PaginationArgs) async throws -> Page<Post> {
@@ -49,18 +49,15 @@ extension RegisteredUser {
     
     // self refers to the context user, not the user being resolved
     func followsSelf(request: Request, arguments: NoArguments) async throws -> Bool {
-        let token = try await getAndVerifyAccessToken(req: request)
-        return try await self.$following.isAttached(toID: token.id, on: request.db)
+        return try await self.$following.isAttached(toID: request.token.id, on: request.db)
     }
     
     func followedBySelf(request: Request, arguments: NoArguments) async throws -> Bool {
-        let token = try await getAndVerifyAccessToken(req: request)
-        return try await self.$followers.isAttached(toID: token.id, on: request.db)
+        return try await self.$followers.isAttached(toID: request.token.id, on: request.db)
     }
     
     func getNotifications(request: Request, arguments: NoArguments) async throws -> [Notification] {
-        let token = try await getAndVerifyAccessToken(req: request)
-        if token.id != self.id {
+        if request.token.id != self.id {
             throw Abort(.forbidden)
         }
         return try await self.$notifications.query(on: request.db).all()

--- a/Sources/App/Util/ScopeValidator.swift
+++ b/Sources/App/Util/ScopeValidator.swift
@@ -10,13 +10,11 @@ import Fluent
 
 
 func checkScope(request: Request, _ scopes: [Scopes]) async throws -> Bool {
-    let token = try await getAndVerifyAccessToken(req: request)
-    return token.perm.hasScope(scopes)
+    return request.token.perm.hasScope(scopes)
 }
 
 func checkScope(request: Request, _ scope: Scopes) async throws -> Bool {
-    let token = try await getAndVerifyAccessToken(req: request)
-    return token.perm.hasScope(scope)
+    return request.token.perm.hasScope(scope)
 }
 
 func assertScope(request: Request, _ scopes: [Scopes]) async throws {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -42,7 +42,7 @@ public func configure(_ app: Application) async throws {
         allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin]
     )
 
-    app.middleware.use(DataLoaderMiddleware())
+    app.middleware.use(GraphQLMiddleware())
     app.middleware.use(CORSMiddleware(configuration: corsConfiguration), at: .beginning)
     
     app.smtp.configuration.hostname = appConfig.smtp.host

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -41,6 +41,8 @@ public func configure(_ app: Application) async throws {
         allowedMethods: [.GET, .POST, .PUT, .OPTIONS, .DELETE, .PATCH],
         allowedHeaders: [.accept, .authorization, .contentType, .origin, .xRequestedWith, .userAgent, .accessControlAllowOrigin]
     )
+
+    app.middleware.use(DataLoaderMiddleware())
     app.middleware.use(CORSMiddleware(configuration: corsConfiguration), at: .beginning)
     
     app.smtp.configuration.hostname = appConfig.smtp.host


### PR DESCRIPTION
Closes #2 

Fixes the N+1 problem

- Allow reusing objects in a query
- Allow batching individual queries into one larger query
- Reuses verified JWTs. No more verifying tokens in resolvers.
- Improve overall scalability